### PR TITLE
Enhance exception tests

### DIFF
--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -11,7 +11,7 @@ final class FileNotFoundException extends InvalidArgumentException implements Lo
     public static function fromFileName(string $filename): self
     {
         return new self(sprintf(
-            'Unable to find lockfile "%s"',
+            'Unable to find locked file "%s"',
             $filename
         ));
     }

--- a/src/LockFile.php
+++ b/src/LockFile.php
@@ -59,11 +59,11 @@ final class LockFile
 
     public function hasProdPackage(string $package): bool
     {
-        return array_key_exists($package, $this->packages);
+        return \array_key_exists($package, $this->packages);
     }
 
     public function hasDevPackage(string $devPackage): bool
     {
-        return array_key_exists($devPackage, $this->devPackages);
+        return \array_key_exists($devPackage, $this->devPackages);
     }
 }

--- a/tests/Exception/FileNotFoundExceptionTest.php
+++ b/tests/Exception/FileNotFoundExceptionTest.php
@@ -24,7 +24,7 @@ final class FileNotFoundExceptionTest extends TestCase
     public function test_it_has_the_correct_error_message(): void
     {
         $filename = 'foo/bar.lock';
-        $message = 'Unable to find lockfile "foo/bar.lock"';
+        $message = 'Unable to find locked file "foo/bar.lock"';
 
         $exception = FileNotFoundException::fromFileName($filename);
         $this->assertSame($message, $exception->getMessage());

--- a/tests/LockFileTest.php
+++ b/tests/LockFileTest.php
@@ -22,14 +22,17 @@ final class LockFileTest extends TestCase
     {
         $this->expectException(FileNotFoundException::class);
         $this->expectException(LockFileException::class);
+        $this->expectExceptionMessage('Unable to find locked file "foo/bar.lock"');
         LockFile::fromFile('foo/bar.lock');
     }
 
     public function test_it_throws_an_exception_if_the_file_contains_invalid_json(): void
     {
+        $invalidLockFile = __DIR__.'/Fixtures/invalid_composer.lock';
         $this->expectException(InvalidJsonException::class);
         $this->expectException(LockFileException::class);
-        LockFile::fromFile(__DIR__.'/Fixtures/invalid_composer.lock');
+        $this->expectExceptionMessage('File "'.$invalidLockFile.'" contains invalid JSON and could not be parsed');
+        LockFile::fromFile($invalidLockFile);
     }
 
     public function test_it_returns_an_instance_of_itself_when_provided_with_valid_json_file(): void


### PR DESCRIPTION
# Changed log
- Adding the `expectExceptionMessage` to assert the expected exception message is same as result.
- Fix `FileNotFoundException` message typo.